### PR TITLE
update: plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -13,9 +13,8 @@
             "icon": "logo.png",
             "cmds": [
                 {
-                    "type": "regex",
-                    "label": "将变量名转换为",
-                    "match": "/^[a-zA-Z][a-zA-Z0-9-_ ]+$/i"
+                    "type": "over",
+                    "label": "将变量名转换为"
                 }
             ]
         },


### PR DESCRIPTION
 // 注意：“任意匹配的正则” 会被 uTools 忽视，如果要任意匹配请使用 "任意文本 - 关键字"。例如：/.*/ 、/(.)+/、/[\s\S]*/ ...
软件逻辑调整